### PR TITLE
Remove default-features from k8s-openapi

### DIFF
--- a/korrecte-lib/Cargo.toml
+++ b/korrecte-lib/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Guillem Nieto <gnieto.talo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-k8s-openapi = { version = "0.5.1", features = ["v1_15"] }
+k8s-openapi = { version = "0.5.1", features = ["v1_15"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 serde_json = "1.0"


### PR DESCRIPTION
Disabling default features on k8s-openapi implies that all the api
objects won't be compiled, speeding up a little bit the build time.