### PR TITLE
Load in cluster config as fallback to kubeconfig

### DIFF
--- a/korrecte-lib/src/kube/api.rs
+++ b/korrecte-lib/src/kube/api.rs
@@ -28,7 +28,7 @@ pub struct ApiObjectRepository {
 
 impl ApiObjectRepository {
     pub fn new() -> Result<Self> {
-        let kube_config = kube_config::load_kube_config()?;
+        let kube_config = kube_config::load_kube_config().or(kube_config::incluster_config())?;
         let client = APIClient::new(kube_config);
 
         Ok(ApiObjectRepository {


### PR DESCRIPTION
If the application fails to load kubeconfig, we will fallback to load
the incluster config.