### PR TITLE
Generate docker image for webservice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+.idea
+tests
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM clux/muslrust
+RUN mkdir /source
+WORKDIR /source
+COPY ./Cargo.toml .
+COPY ./Cargo.lock .
+COPY ./korrecte-autogen/ /source/korrecte-autogen/
+COPY ./korrecte-cli/ /source/korrecte-cli/
+COPY ./korrecte-lib/ /source/korrecte-lib/
+COPY ./korrecte-web/ /source/korrecte-web/
+RUN cargo build --release --bin korrecte-web
+RUN strip ./target/x86_64-unknown-linux-musl/release/korrecte-web
+RUN cargo build --release --bin korrecte-cli
+RUN strip ./target/x86_64-unknown-linux-musl/release/korrecte-cli
+COPY ./korrecte.toml .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=0 /source/target/x86_64-unknown-linux-musl/release/korrecte-web /
+COPY --from=0 /source/target/x86_64-unknown-linux-musl/release/korrecte-cli /
+COPY --from=0 /source/korrecte.toml /


### PR DESCRIPTION
Initial Dockerfile to create an image for the webserver (to be able to
deploy the linter on the cluster).

The Dockerfile is not very optimized for cacheability yet.