### PR TITLE
Extend ALB ingress controller lint

### DIFF
--- a/korrecte-lib/src/linters/lints/alb_ingress_instance.rs
+++ b/korrecte-lib/src/linters/lints/alb_ingress_instance.rs
@@ -4,8 +4,11 @@ use crate::f;
 use crate::linters::evaluator::Context;
 use crate::reporting::Finding;
 use k8s_openapi::api::core::v1::Service;
+use k8s_openapi::api::extensions::v1beta1::Ingress as LegacyIngress;
 use k8s_openapi::api::networking::v1beta1::Ingress;
-use std::collections::HashSet;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use std::collections::hash_map::RandomState;
+use std::collections::{BTreeMap, HashSet};
 
 /// **What it does:** Checks that all ALB ingresses are linked to services which have compatible types
 /// with the ingress. When the ingress is configured with target-type `instance`, only `NodePort` and `LoadBalancer`
@@ -23,26 +26,11 @@ pub(crate) struct AlbIngressInstance;
 
 impl Lint for AlbIngressInstance {
     fn networking_v1beta1_ingress(&self, ingress: &Ingress, context: &Context) {
-        let is_alb_ingress = f!(ingress.metadata, annotations)
-            .and_then(|a| a.get("kubernetes.io/ingress.class"))
-            .map(|class| class == "alb")
-            .unwrap_or(false);
+        self.lint_alb_ingress(ingress, context);
+    }
 
-        if !is_alb_ingress {
-            return;
-        }
-
-        let services = Self::extract_service_names(ingress);
-        let ingress_type = IngressType::from(ingress);
-        let misconfigured_services =
-            self.get_misconfigured_services(context, &ingress_type, services);
-
-        for service in misconfigured_services {
-            let finding = Finding::new(Self::spec(), ingress.metadata.clone())
-                .add_metadata("service", f!(service.metadata, name).cloned().unwrap());
-
-            context.reporter.report(finding);
-        }
+    fn extensions_v1beta1_ingress(&self, ingress: &LegacyIngress, context: &Context) {
+        self.lint_alb_ingress(ingress, context);
     }
 }
 
@@ -51,6 +39,24 @@ impl AlbIngressInstance {
         LintSpec {
             group: Group::Configuration,
             name: "alb_ingress_controller_instance_misconfiguration".to_string(),
+        }
+    }
+
+    fn lint_alb_ingress(&self, ingress: &dyn IngressExt, context: &Context) {
+        if !ingress.is_alb() {
+            return;
+        }
+
+        let services = ingress.get_service_names();
+        let ingress_type = IngressType::from(ingress.metadata());
+        let misconfigured_services =
+            self.get_misconfigured_services(context, &ingress_type, services);
+
+        for service in misconfigured_services {
+            let finding = Finding::new(Self::spec(), ingress.metadata().cloned())
+                .add_metadata("service", f!(service.metadata, name).cloned().unwrap());
+
+            context.reporter.report(finding);
         }
     }
 
@@ -92,23 +98,6 @@ impl AlbIngressInstance {
 
         !ingress_type.is_service_type_allowed(&service_type)
     }
-
-    fn extract_service_names(ingress: &Ingress) -> HashSet<String> {
-        let empty = Vec::new();
-
-        f!(ingress.spec, rules)
-            .unwrap_or(&empty)
-            .iter()
-            .flat_map(|rule| {
-                rule.http.as_ref().map(|http| {
-                    http.paths
-                        .iter()
-                        .map(|path| path.backend.service_name.clone())
-                        .collect()
-                })
-            })
-            .collect()
-    }
 }
 
 enum IngressType {
@@ -117,9 +106,10 @@ enum IngressType {
     Other,
 }
 
-impl From<&Ingress> for IngressType {
-    fn from(ingress: &Ingress) -> Self {
-        let target_type = f!(ingress.metadata, annotations)
+impl From<Option<&ObjectMeta>> for IngressType {
+    fn from(metadata: Option<&ObjectMeta>) -> Self {
+        let target_type = metadata
+            .and_then(|m| m.annotations.as_ref())
             .and_then(|a| a.get("alb.ingress.kubernetes.io/target-type"))
             .map(|target_type| target_type.as_str());
 
@@ -141,6 +131,73 @@ impl IngressType {
             IngressType::Ip => lower_type == "clusterip",
             IngressType::Other => false,
         }
+    }
+}
+
+trait IngressExt {
+    fn is_alb(&self) -> bool;
+    fn get_service_names(&self) -> HashSet<String>;
+    fn metadata(&self) -> Option<&ObjectMeta>;
+
+    fn has_alb_annotation(&self, annotations: Option<&BTreeMap<String, String>>) -> bool {
+        annotations
+            .and_then(|a| a.get("kubernetes.io/ingress.class"))
+            .map(|class| class == "alb")
+            .unwrap_or(false)
+    }
+}
+
+impl IngressExt for Ingress {
+    fn is_alb(&self) -> bool {
+        self.has_alb_annotation(f!(self.metadata, annotations))
+    }
+
+    fn get_service_names(&self) -> HashSet<String, RandomState> {
+        let empty = Vec::new();
+
+        f!(self.spec, rules)
+            .unwrap_or(&empty)
+            .iter()
+            .flat_map(|rule| {
+                rule.http.as_ref().map(|http| {
+                    http.paths
+                        .iter()
+                        .map(|path| path.backend.service_name.clone())
+                        .collect()
+                })
+            })
+            .collect()
+    }
+
+    fn metadata(&self) -> Option<&ObjectMeta> {
+        self.metadata.as_ref()
+    }
+}
+
+impl IngressExt for LegacyIngress {
+    fn is_alb(&self) -> bool {
+        self.has_alb_annotation(f!(self.metadata, annotations))
+    }
+
+    fn get_service_names(&self) -> HashSet<String, RandomState> {
+        let empty = Vec::new();
+
+        f!(self.spec, rules)
+            .unwrap_or(&empty)
+            .iter()
+            .flat_map(|rule| {
+                rule.http.as_ref().map(|http| {
+                    http.paths
+                        .iter()
+                        .map(|path| path.backend.service_name.clone())
+                        .collect()
+                })
+            })
+            .collect()
+    }
+
+    fn metadata(&self) -> Option<&ObjectMeta> {
+        self.metadata.as_ref()
     }
 }
 
@@ -166,6 +223,19 @@ mod tests {
         assert_eq!(
             findings[1].lint_metadata().get("service").unwrap(),
             "service-node-port"
+        );
+    }
+
+    #[test]
+    fn it_finds_misconfigured_services_on_extensions_alb_ingress_configured_as_instance() {
+        let findings = analyze_file(Path::new("../tests/alb_ingress_ext.yaml"));
+        let findings = filter_findings_by(findings, &AlbIngressInstance::spec());
+
+        assert_eq!(1, findings.len());
+        assert_eq!(findings[0].name(), "missconfigured-ext-alb");
+        assert_eq!(
+            findings[0].lint_metadata().get("service").unwrap(),
+            "service-cluster-ip"
         );
     }
 }

--- a/tests/alb_ingress_ext.yaml
+++ b/tests/alb_ingress_ext.yaml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: missconfigured-ext-alb
+  annotations:
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+    - host: domain.test
+      http:
+        paths:
+          - backend:
+              serviceName: service-cluster-ip
+              servicePort: 24322
+            path: /*
+    - host: anotherdomain.test
+      http:
+        paths:
+          - backend:
+              serviceName: service-node-port
+              servicePort: 24322
+            path: /*
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-node-port
+spec:
+  ports:
+    - name: http
+      port: 24322
+      protocol: TCP
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-cluster-ip
+spec:
+  ports:
+    - name: http
+      port: 24322
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
Extend lint to allow ingresses for both extenions/v1beta1 (legacy) and
networking.k8s.io/v1beta1 (new).

I thought on conveting the legacy data structures to the new one and
apply the lint always on the new one, but I finally decided to extract
the logic on an extension trait.