### PR TITLE
Add names security groups on ALB ingresses lint

### DIFF
--- a/korrecte-lib/src/linters/lints/alb_named_sg.rs
+++ b/korrecte-lib/src/linters/lints/alb_named_sg.rs
@@ -1,0 +1,75 @@
+use crate::f;
+use crate::linters::evaluator::Context;
+use crate::linters::Lint;
+use crate::reporting::Finding;
+use k8s_openapi::api::networking::v1beta1::Ingress;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+pub(crate) struct AlbNamedSecurityGroups;
+
+const LINT_NAME: &str = "alb_named_sg";
+const ANNOTATION_NAME: &str = "alb.ingress.kubernetes.io/security-groups";
+
+impl Lint for AlbNamedSecurityGroups {
+    fn name(&self) -> &str {
+        LINT_NAME
+    }
+
+    fn extensions_v1beta1_ingress(
+        &self,
+        ingress: &k8s_openapi::api::extensions::v1beta1::Ingress,
+        context: &Context,
+    ) {
+        let security_groups =
+            f!(ingress.metadata, annotations).and_then(|a| a.get(ANNOTATION_NAME));
+
+        if let Some(security_groups) = security_groups {
+            Self::check_security_groups(security_groups, &ingress.metadata, context);
+        }
+    }
+
+    fn networking_v1beta1_ingress(&self, ingress: &Ingress, context: &Context) {
+        let security_groups =
+            f!(ingress.metadata, annotations).and_then(|a| a.get(ANNOTATION_NAME));
+
+        if let Some(security_groups) = security_groups {
+            Self::check_security_groups(security_groups, &ingress.metadata, context);
+        }
+    }
+}
+
+impl AlbNamedSecurityGroups {
+    fn check_security_groups(
+        security_groups: &str,
+        metadata: &Option<ObjectMeta>,
+        context: &Context,
+    ) {
+        let uses_security_group_id: Vec<&str> = security_groups
+            .split(',')
+            .filter(|security_group| security_group.starts_with("sg-"))
+            .collect();
+
+        if uses_security_group_id.is_empty() {
+            return;
+        }
+
+        let finding = Finding::new(LINT_NAME, metadata.clone())
+            .add_metadata("invalid_security_groups", uses_security_group_id.join(","));
+        context.reporter.report(finding);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{analyze_file, filter_findings_by};
+    use std::path::Path;
+
+    #[test]
+    fn checks_alb_named_security_groups() {
+        let findings = analyze_file(Path::new("../tests/alb_named_sg.yaml"));
+        let findings = filter_findings_by(findings, super::LINT_NAME);
+
+        assert_eq!(1, findings.len());
+        assert_eq!("alb-named-incorrect", findings[0].name());
+    }
+}

--- a/korrecte-lib/src/linters/lints/mod.rs
+++ b/korrecte-lib/src/linters/lints/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod alb_ingress_instance;
+pub(crate) mod alb_named_sg;
 pub(crate) mod environment_passwords;
 pub(crate) mod hpa_no_request;
 pub(crate) mod never_restart_with_liveness_probe;

--- a/korrecte-lib/src/linters/mod.rs
+++ b/korrecte-lib/src/linters/mod.rs
@@ -72,6 +72,7 @@ pub struct LintCollection;
 impl LintCollection {
     pub fn all<'a>(cfg: Config) -> LintList<'a> {
         let alb_ingress = linters::lints::alb_ingress_instance::AlbIngressInstance {};
+        let alb_named_sg = linters::lints::alb_named_sg::AlbNamedSecurityGroups {};
         let passwords = linters::lints::environment_passwords::EnvironmentPasswords::new(
             cfg.environment_passwords.clone(),
         );
@@ -89,6 +90,7 @@ impl LintCollection {
 
         vec![
             Box::new(alb_ingress),
+            Box::new(alb_named_sg),
             Box::new(passwords),
             Box::new(hpa_no_request),
             Box::new(never),

--- a/lints.yaml
+++ b/lints.yaml
@@ -55,3 +55,8 @@ specs:
     description: Finds HPAs which are linked to some controller which contains any container that does not set the requirement fro the target metric. On those cases, the HPA emits some warnings and is not scaling the controller as required.
     references:
       - "https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#how-does-the-horizontal-pod-autoscaler-work"
+  - name: alb_named_sg
+    group: Configuration
+    description: Finds ingresses of type ALB which uses identifiers instead of names on security group defintion. Using named security groups it's more semantic, less error prone and easy to verfiy that the configuration is correct.
+    references:
+      - "https://github.com/HotelsDotCom/alb-ingress-controller/blob/37cfd6fe1f0863a6d35d83d2d2faab2c72f49e9a/docs/ingress-resources.md"

--- a/tests/alb_named_sg.yaml
+++ b/tests/alb_named_sg.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: "sg-1234567,sg-999"
+    kubernetes.io/ingress.class: alb
+  name: alb-named-incorrect
+spec:
+  rules:
+    - host: "host"
+      http:
+        paths:
+          - backend:
+              serviceName: svc_name
+              servicePort: 1234
+            path: /*
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/security-groups: "named-security-group"
+    kubernetes.io/ingress.class: alb
+  name: alb-named-incorrect
+spec:
+  rules:
+    - host: "host"
+      http:
+        paths:
+          - backend:
+              serviceName: svc_name
+              servicePort: 1234
+            path: /*


### PR DESCRIPTION
Finds ingresses of type ALB which uses identifiers instead of names on
security group defintion. Using named security groups it's more
semantic, less error prone and easy to verfiy that the configuration is
correct.

Close https://github.com/gnieto/korrecte/issues/28